### PR TITLE
Updated `base62` dependency to version 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/qtfkwk/base62-uuid"
 
 [dependencies]
-base62 = "1.1.5"
+base62 = "2.0.0"
 clap = { version = "3.1.8", features = ["derive"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 


### PR DESCRIPTION
The new major version of the `base62` dependency is about 3 times faster for encoding and 6 times faster for decoding.

## Timings of the `roundtrip_100000` test

# Before updating

    Command being timed: "cargo test -- --ignored"
    User time (seconds): 3.11
    System time (seconds): 0.17
    Percent of CPU this job got: 100%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.28

# After updating

    Command being timed: "cargo test -- --ignored"
    User time (seconds): 0.96
    System time (seconds): 0.16
    Percent of CPU this job got: 99%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.13